### PR TITLE
LanguageRepository のSharedPreferencesキャッシュ化

### DIFF
--- a/lib/core/providers/shared_prefs_cache_provider.dart
+++ b/lib/core/providers/shared_prefs_cache_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+final sharedPrefsCacheProvider = StateProvider<SharedPreferences?>((ref) => null);
+
+final initSharedPrefsCacheProvider = FutureProvider<void>((ref) async {
+  final prefs = await SharedPreferences.getInstance();
+  ref.read(sharedPrefsCacheProvider.notifier).state = prefs;
+});

--- a/lib/features/settings_lang_switch/providers/language_repositry_provider.dart
+++ b/lib/features/settings_lang_switch/providers/language_repositry_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:github_browser/core/providers/shared_prefs_cache_provider.dart';
 import 'package:github_browser/features/settings_lang_switch/repositories/language_repository.dart';
 
 final languageRepositoryProvider = Provider<LanguageRepository>((ref) {
-  return LanguageRepository();
+  return LanguageRepository(ref.read(sharedPrefsCacheProvider.notifier).state!);
 });

--- a/lib/features/settings_lang_switch/repositories/language_repository.dart
+++ b/lib/features/settings_lang_switch/repositories/language_repository.dart
@@ -3,14 +3,14 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class LanguageRepository {
   static const String _key = 'selected_language';
+  final SharedPreferences prefs;
+  LanguageRepository(this.prefs);
   
   Future<void> saveLang(Language language) async {
-    final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_key, language.code);
   }
   
   Future<Language> loadLang() async {
-    final prefs = await SharedPreferences.getInstance();
     final value = prefs.getString(_key);
     return 
       value != null 

--- a/lib/features/settings_theme_switch/providers/theme_repository_provider.dart
+++ b/lib/features/settings_theme_switch/providers/theme_repository_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:github_browser/core/providers/shared_prefs_cache_provider.dart';
 import 'package:github_browser/features/settings_theme_switch/repositories/theme_repository.dart';
 
 final themeRepositoryProvider = Provider<ThemeRepository>((ref) {
-  return ThemeRepository();
+  return ThemeRepository(ref.read(sharedPrefsCacheProvider.notifier).state!);
 });

--- a/lib/features/settings_theme_switch/repositories/theme_repository.dart
+++ b/lib/features/settings_theme_switch/repositories/theme_repository.dart
@@ -3,14 +3,14 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class ThemeRepository {
   static const String _key = 'theme_mode';
+  final SharedPreferences prefs;
+  ThemeRepository(this.prefs);
   
   Future<void> saveThemeMode(ThemeMode mode) async {
-    final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_key, mode.index);
   }
   
   Future<ThemeMode> loadThemeMode() async {
-    final prefs = await SharedPreferences.getInstance();
     final value = prefs.getInt(_key);
     return value != null ? ThemeMode.values[value] : ThemeMode.light;
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:github_browser/core/providers/shared_prefs_cache_provider.dart';
 import 'package:github_browser/features/github_auth/components/auth_wrapper.dart';
 import 'package:github_browser/features/settings_lang_switch/providers/language_provider.dart';
 import 'package:github_browser/features/settings_theme_switch/providers/theme_mode_provider.dart';
 import 'package:github_browser/l10n/app_localizations.dart';
 
-void main() {
-  runApp(const ProviderScope(child: MyApp()));
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final container = ProviderContainer();
+  await container.read(initSharedPrefsCacheProvider.future);
+
+  runApp(
+    UncontrolledProviderScope(
+      container: container, 
+      child: const MyApp()
+    )
+  );
 }
 
 class MyApp extends ConsumerWidget {

--- a/test/unit/features/settings_switch_language/repositories/language_repository_test.dart
+++ b/test/unit/features/settings_switch_language/repositories/language_repository_test.dart
@@ -1,34 +1,46 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:github_browser/features/settings_lang_switch/entities/langs.dart';
 import 'package:github_browser/features/settings_lang_switch/entities/language.dart';
 import 'package:github_browser/features/settings_lang_switch/repositories/language_repository.dart';
 import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-@GenerateMocks([])
+import 'language_repository_test.mocks.dart';
+
+@GenerateMocks([SharedPreferences])
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  late MockSharedPreferences mockSharedPreferences;
   late LanguageRepository languageRepository;
 
   setUp(() {
-    languageRepository = LanguageRepository();
+    mockSharedPreferences = MockSharedPreferences();
+    languageRepository = LanguageRepository(mockSharedPreferences);
   });
 
   group('LanguageRepository', () {
     test('SharedPreferencesに保存できること', () async {
-      SharedPreferences.setMockInitialValues({});
+      when(mockSharedPreferences.setString('selected_language', Language.japanese.code))
+        .thenAnswer((_) async => true);
+
+      when(mockSharedPreferences.getString('selected_language'))
+        .thenReturn(Language.japanese.code);
 
       await languageRepository.saveLang(Language.japanese);
 
-      final prefs = await SharedPreferences.getInstance();
-      final savedValue = prefs.getString('selected_language');
+      verify(mockSharedPreferences.setString('selected_language', Language.japanese.code)).called(1);
+
+      final savedValue = mockSharedPreferences.getString('selected_language');
 
       expect(savedValue, Language.japanese.code);
     });
 
     test('SharedPreferencesから言語をロードできること', () async {
-      SharedPreferences.setMockInitialValues({
-        'selected_language': Language.japanese.code
-      });
+      when(mockSharedPreferences.getString('selected_language'))
+        .thenReturn(Language.japanese.code);
       
       final lang = await languageRepository.loadLang();
       
@@ -36,7 +48,8 @@ void main() {
     });
 
     test('SharedPreferencesでエラーが発生した際にLanguage.japaneseを返すこと', () async {
-      SharedPreferences.setMockInitialValues({});
+      when(mockSharedPreferences.getString('selected_language'))
+        .thenReturn(null);
       
       final lang = await languageRepository.loadLang();
       
@@ -48,12 +61,19 @@ void main() {
         SharedPreferences.setMockInitialValues({});
         
         final Language language = Language.fromCode(value.code);
+
+        when(mockSharedPreferences.setString('selected_language', language.code))
+          .thenAnswer((_) async => true);
+        when(mockSharedPreferences.getString('selected_language'))
+          .thenReturn(language.code);
         
         await languageRepository.saveLang(language);
         
         final loadedMode = await languageRepository.loadLang();
         
         expect(loadedMode, language);
+        
+        verify(mockSharedPreferences.setString('selected_language', language.code)).called(1);
       }
     });
   });

--- a/test/unit/features/settings_switch_theme/repositories/theme_repository_test.dart
+++ b/test/unit/features/settings_switch_theme/repositories/theme_repository_test.dart
@@ -2,54 +2,64 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:github_browser/features/settings_theme_switch/repositories/theme_repository.dart';
 import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-///これはThemeModeをEntityとみなす。
-@GenerateMocks([])
+import 'theme_repository_test.mocks.dart';
+
+@GenerateMocks([SharedPreferences])
 void main() {
+  late MockSharedPreferences mockSharedPreferences;
   late ThemeRepository themeRepository;
 
   setUp(() {
-    themeRepository = ThemeRepository();
+    mockSharedPreferences = MockSharedPreferences();
+    themeRepository = ThemeRepository(mockSharedPreferences);
   });
 
   group('ThemeRepository', () {
     test('SharedPreferencesに保存できること', () async {
-      SharedPreferences.setMockInitialValues({});
+      when(
+        mockSharedPreferences.setInt('theme_mode', ThemeMode.dark.index),
+      ).thenAnswer((_) async => true);
+      when(mockSharedPreferences.getInt('theme_mode')).thenReturn(ThemeMode.dark.index);
 
       await themeRepository.saveThemeMode(ThemeMode.dark);
 
-      final prefs = await SharedPreferences.getInstance();
-      final savedValue = prefs.getInt('theme_mode');
+      verify(mockSharedPreferences.setInt('theme_mode', ThemeMode.dark.index)).called(1);
 
+      final savedValue = mockSharedPreferences.getInt('theme_mode');
       expect(savedValue, ThemeMode.dark.index);
     });
 
     test('SharedPreferencesからテーマをロードできること', () async {
-      SharedPreferences.setMockInitialValues({'theme_mode': ThemeMode.light.index});
-      
+      when(mockSharedPreferences.getInt('theme_mode')).thenReturn(ThemeMode.light.index);
+
       final themeMode = await themeRepository.loadThemeMode();
-      
+
       expect(themeMode, ThemeMode.light);
+      verify(mockSharedPreferences.getInt('theme_mode')).called(1);
     });
 
     test('SharedPreferencesでエラーが発生した際にlightを返すこと', () async {
-      SharedPreferences.setMockInitialValues({});
-      
+      when(mockSharedPreferences.getInt('theme_mode')).thenReturn(null);
+
       final themeMode = await themeRepository.loadThemeMode();
-      
+
       expect(themeMode, ThemeMode.light);
+      verify(mockSharedPreferences.getInt('theme_mode')).called(1);
     });
 
     test('正常に保存できて、ロードできること', () async {
       for (final mode in ThemeMode.values) {
-        SharedPreferences.setMockInitialValues({});
-        
+        when(mockSharedPreferences.setInt('theme_mode', mode.index)).thenAnswer((_) async => true);
+        when(mockSharedPreferences.getInt('theme_mode')).thenReturn(mode.index);
+
         await themeRepository.saveThemeMode(mode);
-        
         final loadedMode = await themeRepository.loadThemeMode();
-        
+
         expect(loadedMode, mode);
+        verify(mockSharedPreferences.setInt('theme_mode', mode.index)).called(1);
       }
     });
   });


### PR DESCRIPTION
## 実施タスク
- [x] SharedPrefsのRiverpodでキャッシュ化

## 実施内容
- SharedPrefsCacheProviderの追加
- laguage_repository_testとtheme_repository_testにてキャッシュ化されたprefsを有効化
- mainにてそれらの初期化処理を追加

## 備考
