### PR TITLE
ログ出力方法の変更（debugPrintからlogへ）

### DIFF
--- a/lib/features/github_auth/repositories/github_auth_repository.dart
+++ b/lib/features/github_auth/repositories/github_auth_repository.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer';
 
 import 'package:app_links/app_links.dart';
 import 'package:flutter/material.dart';
@@ -55,18 +56,18 @@ class GithubAuthRepository {
         basicAuth: false,
       );
 
-      debugPrint('使用するリダイレクトURL: $redirectUrl');
+      log('使用するリダイレクトURL: $redirectUrl');
       final authorizationUrl = grant.getAuthorizationUrl(redirectUrl, scopes: scopes);
-      debugPrint('GitHub認証URL: $authorizationUrl');
+      log('GitHub認証URL: $authorizationUrl');
 
       await _redirectToBrowser(authorizationUrl);
       
-      debugPrint('リダイレクトを待機中...');
+      log('リダイレクトを待機中...');
       final responseUrl = await _listenForAppLink();
-      debugPrint('リダイレクトURLを受信: $responseUrl');
+      log('リダイレクトURLを受信: $responseUrl');
       
-      debugPrint('認証レスポンスを処理中...');
-      debugPrint('レスポンスパラメータ: ${responseUrl.queryParameters}');
+      log('認証レスポンスを処理中...');
+      log('レスポンスパラメータ: ${responseUrl.queryParameters}');
 
       final code = responseUrl.queryParameters['code'];
       if (code == null) return AuthResult.failure("responseUrl.queryParameters code is null");
@@ -94,8 +95,8 @@ class GithubAuthRepository {
         throw Exception('Failed to get access token: ${response.body}');
       }
     } catch (e, stackTrace) {
-      debugPrint('認証プロセス中にエラーが発生しました: $e');
-      debugPrint('スタックトレース: $stackTrace');
+      log('認証プロセス中にエラーが発生しました: $e');
+      log('スタックトレース: $stackTrace');
     } finally {
       await _linkSubscription?.cancel();
       _linkSubscription = null;
@@ -110,21 +111,21 @@ class GithubAuthRepository {
     try {
       final initialLink = await appLinks.getInitialLink();
       if (initialLink != null && initialLink.queryParameters.containsKey('code')) {
-        debugPrint('初期App Linkからコードを検出: ${initialLink.queryParameters['code']}');
+        log('初期App Linkからコードを検出: ${initialLink.queryParameters['code']}');
         completer.complete(initialLink);
         return completer.future;
       }
     } catch (e) {
-      debugPrint('初期App Linkの取得エラー: $e');
+      log('初期App Linkの取得エラー: $e');
     }
     
     _linkSubscription = appLinks.uriLinkStream.listen((Uri uri) {
       if (!completer.isCompleted && uri.queryParameters.containsKey('code')) {
-        debugPrint('App Linkからコードを検出: ${uri.queryParameters['code']}');
+        log('App Linkからコードを検出: ${uri.queryParameters['code']}');
         completer.complete(uri);
       }
     }, onError: (dynamic error) {
-      debugPrint('App Linkエラー: $error');
+      log('App Linkエラー: $error');
       if (!completer.isCompleted) {
         completer.completeError(error);
       }
@@ -134,8 +135,8 @@ class GithubAuthRepository {
   }
   
   Future<void> _redirectToBrowser(Uri url) async {
-    debugPrint('以下のURLをブラウザで開いてGitHubにログインしてください:');
-    debugPrint(url.toString());
+    log('以下のURLをブラウザで開いてGitHubにログインしてください:');
+    log(url.toString());
 
     urlLauncher.launch(
       url,

--- a/lib/features/github_auth/repositories/github_auth_repository.dart
+++ b/lib/features/github_auth/repositories/github_auth_repository.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:developer';
 
 import 'package:app_links/app_links.dart';
-import 'package:flutter/material.dart';
 import 'package:github_browser/features/github_auth/entities/auth_result.dart';
 import 'package:oauth2/oauth2.dart';
 import 'package:github_browser/core/env/env.dart';

--- a/lib/features/repo_search/repositories/github_repository.dart
+++ b/lib/features/repo_search/repositories/github_repository.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
+import 'dart:developer';
 import 'package:github_browser/core/exceptions/github_api_exception.dart';
 import 'package:github_browser/features/repo_search/entities/repository.dart';
 // ignore: depend_on_referenced_packages
 import 'package:http/http.dart' as http;
-import 'package:flutter/foundation.dart';
 import 'package:github_browser/core/env/env.dart';
 
 class GitHubRepository {
@@ -38,7 +38,7 @@ class GitHubRepository {
 
       return items.map((item) => _mapToRepository(item)).toList();
     } catch (e) {
-      debugPrint('リポジトリ検索中にエラーが発生しました: $e');
+      log('リポジトリ検索中にエラーが発生しました: $e');
       rethrow;
     }
   }
@@ -54,7 +54,7 @@ class GitHubRepository {
 
       return _mapToRepository(repoData, issueCount: issueCount);
     } catch (e) {
-      debugPrint('リポジトリ詳細の取得中にエラーが発生しました: $e');
+      log('リポジトリ詳細の取得中にエラーが発生しました: $e');
       rethrow;
     }
   }
@@ -96,7 +96,7 @@ class GitHubRepository {
       final issues = jsonDecode(issuesResponse.body) as List;
       return issues.length;
     } catch (e) {
-      debugPrint('Issue数の取得中にエラーが発生しました: $e');
+      log('Issue数の取得中にエラーが発生しました: $e');
       return 0;
     }
   }

--- a/test/unit/features/github_auth/repositories/github_auth_repository_test.dart
+++ b/test/unit/features/github_auth/repositories/github_auth_repository_test.dart
@@ -4,7 +4,6 @@ import 'dart:developer';
 import 'dart:io';
 
 import 'package:app_links/app_links.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:github_browser/core/env/env.dart';
 import 'package:github_browser/features/github_auth/entities/auth_result.dart';

--- a/test/unit/features/github_auth/repositories/github_auth_repository_test.dart
+++ b/test/unit/features/github_auth/repositories/github_auth_repository_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:developer';
 import 'dart:io';
 
 import 'package:app_links/app_links.dart';
@@ -305,7 +306,7 @@ class _TestGithubAuthRepositoryWithHttpMock extends GithubAuthRepository {
         throw Exception('Failed to get access token: ${response.body}');
       }
     } catch (e) {
-      debugPrint('認証プロセス中にエラーが発生しました: $e');
+      log('認証プロセス中にエラーが発生しました: $e');
     } finally {
       await _linkSubscription?.cancel();
       _linkSubscription = null;
@@ -321,21 +322,21 @@ class _TestGithubAuthRepositoryWithHttpMock extends GithubAuthRepository {
     try {
       final initialLink = await appLinks.getInitialLink();
       if (initialLink != null && initialLink.queryParameters.containsKey('code')) {
-        debugPrint('初期App Linkからコードを検出: ${initialLink.queryParameters['code']}');
+        log('初期App Linkからコードを検出: ${initialLink.queryParameters['code']}');
         completer.complete(initialLink);
         return completer.future;
       }
     } catch (e) {
-      debugPrint('初期App Linkの取得エラー: $e');
+      log('初期App Linkの取得エラー: $e');
     }
     
     _linkSubscription = appLinks.uriLinkStream.listen((Uri uri) {
       if (!completer.isCompleted && uri.queryParameters.containsKey('code')) {
-        debugPrint('App Linkからコードを検出: ${uri.queryParameters['code']}');
+        log('App Linkからコードを検出: ${uri.queryParameters['code']}');
         completer.complete(uri);
       }
     }, onError: (dynamic error) {
-      debugPrint('App Linkエラー: $error');
+      log('App Linkエラー: $error');
       if (!completer.isCompleted) {
         completer.completeError(error);
       }
@@ -345,8 +346,8 @@ class _TestGithubAuthRepositoryWithHttpMock extends GithubAuthRepository {
   }
   
   Future<void> _redirectToBrowser(Uri url) async {
-    debugPrint('以下のURLをブラウザで開いてGitHubにログインしてください:');
-    debugPrint(url.toString());
+    log('以下のURLをブラウザで開いてGitHubにログインしてください:');
+    log(url.toString());
 
     urlLauncher.launch(
       url,


### PR DESCRIPTION
## 実施タスク
- [x] ログ出力方法の変更（debugPrintからdart:developperのlogへ）

## 実施内容
- github_auth_repositoryとgithub_auth_repository_testとgithub_repositoryのdebugPrintをdart:developperのlogへ修正

## 備考
