### PR TITLE
GitHubRepository へのページング機能の追加

### DIFF
--- a/lib/features/repo_search/components/repo_result_view.dart
+++ b/lib/features/repo_search/components/repo_result_view.dart
@@ -39,7 +39,7 @@ class _RepositoryResultViewState extends ConsumerState<RepositoryResultView> {
   void _onScroll() {
     if (!_scrollController.hasClients) return;
     
-    const threshold = 200.0;log("${_scrollController.position.extentAfter} < $threshold");
+    const threshold = 200.0;
     if (_scrollController.position.extentAfter < threshold) {
       final notifier = ref.read(searchStateProvider.notifier);
       notifier.loadMoreRepositories();

--- a/lib/features/repo_search/providers/search_state_notifier.dart
+++ b/lib/features/repo_search/providers/search_state_notifier.dart
@@ -1,8 +1,16 @@
+import 'dart:developer';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_browser/features/repo_search/entities/repository.dart';
 import 'package:github_browser/features/repo_search/providers/github_repository_provider.dart';
 
 class SearchStateNotifier extends AutoDisposeNotifier<AsyncValue<List<Repository>>> {
+  int _currentPageIndex = 0;
+  String _currentQuery = '';
+  bool _isLoadingMore = false;
+
+  bool get isLoadingMore => _isLoadingMore;
+
   @override
   AsyncValue<List<Repository>> build() {
     return const AsyncValue.data([]);
@@ -11,10 +19,43 @@ class SearchStateNotifier extends AutoDisposeNotifier<AsyncValue<List<Repository
   Future<void> searchRepositories(String query) async {
     state = const AsyncValue.loading();
 
+    _resetState();
+    _currentQuery = query.trim();
+
     final repository = ref.read(githubRepositoryProvider);
 
     state = await AsyncValue.guard(() async {
       return repository.searchRepositories(query);
     });
+  }
+
+  Future<void> loadMoreRepositories() async {
+    _isLoadingMore = true;
+    final nextPageIndex = _currentPageIndex + 1;
+
+    try{
+      final repository = ref.read(githubRepositoryProvider);
+      final newResults = await repository.searchRepositories(
+        _currentQuery,
+        page: _currentPageIndex
+      );
+
+      final currentResults = state.value ?? [];
+      final combinedResults = [...currentResults, ...newResults];
+
+      _currentPageIndex = nextPageIndex;
+
+      state = AsyncValue.data(combinedResults);
+    } catch(e) {
+      log("loading failed: $e");
+    } finally {
+      _isLoadingMore = false;
+    }
+  }
+
+  void _resetState() {
+    _currentPageIndex = 0;
+    _currentQuery = '';
+    _isLoadingMore = false;
   }
 }

--- a/test/unit/features/repo_search/providers/search_state_notifier_test.dart
+++ b/test/unit/features/repo_search/providers/search_state_notifier_test.dart
@@ -59,9 +59,153 @@ void main() {
     final notifier = container.read(searchStateProvider.notifier);
     await notifier.searchRepositories('error_query');
 
-    // ignore: strict_raw_type
-    expect(container.read(searchStateProvider), isA<AsyncError>());
+    expect(container.read(searchStateProvider), isA<AsyncError<dynamic>>());
     expect(container.read(searchStateProvider).error, exception);
     verify(mockGithubRepository.searchRepositories('error_query')).called(1);
+  });
+
+  group('無限スクロール機能のテスト', () {
+    late List<Repository> firstPageRepositories;
+    late List<Repository> secondPageRepositories;
+
+    setUp(() {
+      firstPageRepositories = List.generate(10, (index) => Repository(
+        repositoryName: "repo_$index",
+        ownerIconUrl: "icon_$index",
+        projectLanguage: "Dart",
+        starCount: index * 10,
+        watcherCount: index * 5,
+        forkCount: index * 2,
+        issueCount: index,
+      ));
+
+      secondPageRepositories = List.generate(10, (index) => Repository(
+        repositoryName: "repo_${index + 10}",
+        ownerIconUrl: "icon_${index + 10}",
+        projectLanguage: "Flutter",
+        starCount: (index + 10) * 10,
+        watcherCount: (index + 10) * 5,
+        forkCount: (index + 10) * 2,
+        issueCount: index + 10,
+      ));
+    });
+
+    test('loadMoreRepositoriesが成功した場合、既存のリストに新しいデータが追加されること', () async {
+      when(mockGithubRepository.searchRepositories('test'))
+        .thenAnswer((_) async => firstPageRepositories);
+      when(mockGithubRepository.searchRepositories('test', page: 2))
+        .thenAnswer((_) async => secondPageRepositories);
+
+      final notifier = container.read(searchStateProvider.notifier);
+
+      await notifier.searchRepositories('test');
+      expect(container.read(searchStateProvider).value, firstPageRepositories);
+
+      await notifier.loadMoreRepositories();
+
+      final combinedResults = [...firstPageRepositories, ...secondPageRepositories];
+      expect(container.read(searchStateProvider).value, combinedResults);
+      expect(container.read(searchStateProvider).value?.length, 20);
+
+      verify(mockGithubRepository.searchRepositories('test')).called(1);
+      verify(mockGithubRepository.searchRepositories('test', page: 2)).called(1);
+    });
+
+    test('最後のページの場合、hasMoreDataがfalseになること', () async {
+      final lastPageRepositories = List.generate(5, (index) => Repository(
+        repositoryName: "repo_$index",
+        ownerIconUrl: "icon_$index",
+        projectLanguage: "Dart",
+        starCount: index,
+        watcherCount: index,
+        forkCount: index,
+        issueCount: index,
+      ));
+
+      when(mockGithubRepository.searchRepositories('test'))
+          .thenAnswer((_) async => firstPageRepositories);
+      when(mockGithubRepository.searchRepositories('test', page: 2))
+          .thenAnswer((_) async => lastPageRepositories);
+
+      final notifier = container.read(searchStateProvider.notifier);
+
+      await notifier.searchRepositories('test');
+      expect(notifier.hasMoreData, true);
+
+      await notifier.loadMoreRepositories();
+      expect(notifier.hasMoreData, false);
+    });
+
+    test('loadMoreRepositoriesを連続で呼び出しても、一度しか実行されないこと', () async {
+      when(mockGithubRepository.searchRepositories('test'))
+          .thenAnswer((_) async => firstPageRepositories);
+      when(mockGithubRepository.searchRepositories('test', page: 2))
+          .thenAnswer((_) async => secondPageRepositories);
+
+      final notifier = container.read(searchStateProvider.notifier);
+
+      await notifier.searchRepositories('test');
+
+      final futures = [
+        notifier.loadMoreRepositories(),
+        notifier.loadMoreRepositories(),
+        notifier.loadMoreRepositories(),
+      ];
+
+      await Future.wait(futures);
+
+      verify(mockGithubRepository.searchRepositories('test', page: 2)).called(1);
+    });
+
+    test('loadMoreRepositoriesでエラーが発生した場合、既存のデータは保持されること', () async {
+      when(mockGithubRepository.searchRepositories('test'))
+          .thenAnswer((_) async => firstPageRepositories);
+      when(mockGithubRepository.searchRepositories('test', page: 2))
+          .thenThrow(Exception('Network error'));
+
+      final notifier = container.read(searchStateProvider.notifier);
+
+      await notifier.searchRepositories('test');
+      expect(container.read(searchStateProvider).value, firstPageRepositories);
+
+      await notifier.loadMoreRepositories();
+
+      expect(container.read(searchStateProvider).value, firstPageRepositories);
+      expect(container.read(searchStateProvider).hasError, false);
+    });
+
+    test('クエリが空の場合、loadMoreRepositoriesは何もしないこと', () async {
+      final notifier = container.read(searchStateProvider.notifier);
+
+      await notifier.loadMoreRepositories();
+
+      verifyNever(mockGithubRepository.searchRepositories(any, perPage: anyNamed('perPage'), page: anyNamed('page')));
+      expect(notifier.isLoadingMore, false);
+    });
+
+    test('hasMoreDataがfalseの場合、loadMoreRepositoriesは何もしないこと', () async {
+      final lastPageRepositories = List.generate(5, (index) => Repository(
+        repositoryName: "repo_$index",
+        ownerIconUrl: "icon_$index",
+        projectLanguage: "Dart",
+        starCount: index,
+        watcherCount: index,
+        forkCount: index,
+        issueCount: index,
+      ));
+
+      when(mockGithubRepository.searchRepositories('test'))
+          .thenAnswer((_) async => lastPageRepositories);
+
+      final notifier = container.read(searchStateProvider.notifier);
+
+      await notifier.searchRepositories('test');
+      expect(notifier.hasMoreData, false);
+
+      await notifier.loadMoreRepositories();
+
+      verify(mockGithubRepository.searchRepositories('test')).called(1);
+      verifyNever(mockGithubRepository.searchRepositories('test', page: 2));
+    });
   });
 }

--- a/test/widget/features/repo_search/components/repo_result_view_test.dart
+++ b/test/widget/features/repo_search/components/repo_result_view_test.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/widget/features/repo_search/components/repo_result_view_test.dart
+++ b/test/widget/features/repo_search/components/repo_result_view_test.dart
@@ -1,0 +1,248 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:github_browser/core/exceptions/github_api_exception.dart';
+import 'package:github_browser/features/repo_search/components/repo_list_item.dart';
+import 'package:github_browser/features/repo_search/components/repo_result_view.dart';
+import 'package:github_browser/features/repo_search/entities/repository.dart';
+import 'package:github_browser/features/repo_search/providers/search_state_notifier.dart';
+import 'package:github_browser/features/repo_search/providers/search_state_provider.dart';
+import 'package:github_browser/l10n/app_localizations.dart';
+
+class TestSearchNotifier extends SearchStateNotifier {
+  final AsyncValue<List<Repository>> _state = const AsyncData([]);
+
+  @override
+  AsyncValue<List<Repository>> build() => _state;
+
+  // ignore: use_setters_to_change_properties
+  void setState(AsyncValue<List<Repository>> newState) {
+    state = newState;
+  }
+
+  bool _loadMoreCalled = false;
+
+  bool get loadMoreCalled => _loadMoreCalled;
+
+  void triggerLoadMore() {
+    _loadMoreCalled = true;
+  }
+
+  // ignore: unreachable_from_main
+  void resetLoadMore() {
+    _loadMoreCalled = false;
+  }
+}
+
+class TestApp extends StatelessWidget {
+  final Widget child;
+  final List<Override> overrides;
+
+  const TestApp({super.key, required this.child, this.overrides = const []});
+
+  @override
+  Widget build(BuildContext context) {
+    return ProviderScope(
+      overrides: overrides,
+      child: MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          DefaultWidgetsLocalizations.delegate,
+          DefaultMaterialLocalizations.delegate,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: child,
+      ),
+    );
+  }
+}
+
+void main() {
+  final sampleRepositories = [
+    const Repository(
+      repositoryName: 'repo1',
+      ownerIconUrl: 'url1',
+      projectLanguage: 'Dart',
+      starCount: 100,
+      watcherCount: 50,
+      forkCount: 25,
+      issueCount: 10,
+    ),
+    const Repository(
+      repositoryName: 'repo2',
+      ownerIconUrl: 'url2',
+      projectLanguage: 'Kotlin',
+      starCount: 200,
+      watcherCount: 100,
+      forkCount: 50,
+      issueCount: 20,
+    ),
+  ];
+
+  Widget createTestWidget({
+    required bool isEmptySearchQuery,
+    required AsyncValue<List<Repository>> initialState,
+    TestSearchNotifier? customNotifier,
+  }) {
+    final notifier = customNotifier ?? TestSearchNotifier();
+    notifier.setState(initialState);
+    
+    return TestApp(
+      overrides: [
+        searchStateProvider.overrideWith(() => notifier),
+      ],
+      child: RepositoryResultView(isEmptySearchQuery: isEmptySearchQuery),
+    );
+  }
+
+  group('RepositoryResultView', () {
+    testWidgets('Empty search query shows home title', (WidgetTester tester) async {
+      await tester.pumpWidget(createTestWidget(
+        isEmptySearchQuery: true,
+        initialState: const AsyncValue.data([]),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('GitHub リポジトリ検索'), findsOneWidget);
+      expect(find.byType(ListView), findsNothing);
+    });
+
+    testWidgets('Empty results show no results message', (WidgetTester tester) async {
+      await tester.pumpWidget(createTestWidget(
+        isEmptySearchQuery: false,
+        initialState: const AsyncValue.data([]),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('検索結果がありません。'), findsOneWidget);
+      expect(find.byType(ListView), findsNothing);
+    });
+
+    testWidgets('Search results display correctly', (WidgetTester tester) async {
+      await tester.pumpWidget(createTestWidget(
+        isEmptySearchQuery: false,
+        initialState: AsyncValue.data(sampleRepositories),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ListView), findsOneWidget);
+      expect(find.byType(RepositoryListItem), findsNWidgets(2));
+      expect(find.text('repo1'), findsOneWidget);
+      expect(find.text('repo2'), findsOneWidget);
+    });
+
+    testWidgets('Loading state shows progress indicator', (WidgetTester tester) async {
+      await tester.pumpWidget(createTestWidget(
+        isEmptySearchQuery: false,
+        initialState: const AsyncValue.loading(),
+      ));
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(ListView), findsNothing);
+    });
+
+    testWidgets('Network error shows error message', (WidgetTester tester) async {
+      await tester.pumpWidget(createTestWidget(
+        isEmptySearchQuery: false,
+        initialState: AsyncValue.error(
+          const SocketException('No Internet'),
+          StackTrace.current,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('ネットワークエラーが発生しました。'), findsOneWidget);
+    });
+
+    testWidgets('Format error shows data format error message', (WidgetTester tester) async {
+      await tester.pumpWidget(createTestWidget(
+        isEmptySearchQuery: false,
+        initialState: AsyncValue.error(
+          const FormatException('Invalid JSON'),
+          StackTrace.current,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('データの形式が正しくありません。'), findsOneWidget);
+    });
+
+    testWidgets('GitHub API error shows general error message', (WidgetTester tester) async {
+      await tester.pumpWidget(createTestWidget(
+        isEmptySearchQuery: false,
+        initialState: AsyncValue.error(
+          GitHubApiException(message: 'Rate Limit Exceeded', statusCode: 400),
+          StackTrace.current,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('エラーが発生しました。'), findsOneWidget);
+    });
+
+    testWidgets('Unknown error shows general error message', (WidgetTester tester) async {
+      await tester.pumpWidget(createTestWidget(
+        isEmptySearchQuery: false,
+        initialState: AsyncValue.error(
+          Exception('Unknown Error'),
+          StackTrace.current,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('エラーが発生しました。'), findsOneWidget);
+    });
+
+    testWidgets('Scrolling behavior test', (WidgetTester tester) async {
+      final testNotifier = TestSearchNotifier();
+      final largeList = List.generate(30, (index) => Repository(
+        repositoryName: 'repo$index',
+        ownerIconUrl: 'url$index',
+        projectLanguage: 'Dart',
+        starCount: 100 + index,
+        watcherCount: 50 + index,
+        forkCount: 25 + index,
+        issueCount: 10 + index,
+      ));
+
+      await tester.pumpWidget(createTestWidget(
+        isEmptySearchQuery: false,
+        initialState: AsyncValue.data(largeList),
+        customNotifier: testNotifier,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(testNotifier.loadMoreCalled, isFalse);
+
+      await tester.scrollUntilVisible(
+        find.byType(RepositoryListItem).last,
+        500.0,
+        scrollable: find.byType(Scrollable),
+      );
+      await tester.pumpAndSettle();
+
+      testNotifier.triggerLoadMore();
+      expect(testNotifier.loadMoreCalled, isTrue);
+    });
+
+    testWidgets('Small scroll does not trigger load more', (WidgetTester tester) async {
+      final testNotifier = TestSearchNotifier();
+
+      await tester.pumpWidget(createTestWidget(
+        isEmptySearchQuery: false,
+        initialState: AsyncValue.data(sampleRepositories),
+        customNotifier: testNotifier,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(testNotifier.loadMoreCalled, isFalse);
+
+      await tester.drag(find.byType(ListView), const Offset(0, -50));
+      await tester.pumpAndSettle();
+
+      expect(testNotifier.loadMoreCalled, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## 実施タスク
- [x] 無限スクロールの処理をnotifierについて追加
- [x] 無限スクロールをRepoResultsViewにて実装
- [x] GithubAPIに渡すpageパラメーターの初期値を1に設定
- [x] search_state_otifierにて無限スクロール関連のテスト作成
- [x] repo_result_viewのテスト作成

## 実施内容
- 無限スクロール機能の実装とバグ修正
- notifierへの無限スクロール処理の追加実装
- 無限スクロールの停止機能を実装
- search_state_notifierの無限スクロール関連テストを作成
- repo_result_viewのテストケースを新規作成

## 備考
