### PR TITLE
リダイレクトが正常に実行されなかった際の再試行を実装

### DIFF
--- a/lib/core/routes/router.dart
+++ b/lib/core/routes/router.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_browser/core/routes/app_routes.dart';
 import 'package:github_browser/features/github_auth/providers/signin_state_provider.dart';
 import 'package:github_browser/features/repo_search/entities/repository.dart';
+import 'package:github_browser/pages/redirect_indicator_page.dart';
 import 'package:github_browser/pages/repo_detail_page.dart';
 import 'package:github_browser/pages/search_page.dart';
 import 'package:github_browser/pages/settings_page.dart';
@@ -54,12 +55,9 @@ GoRouter createGoRouter(
         path: AppRoutes.initialPage,
         name: 'initial',
         pageBuilder: (context, state) {
-          return const MaterialPage(
-            child: Scaffold(
-              body: Center(
-                child: CircularProgressIndicator(),
-              ),
-            ),
+          return MaterialPage(
+            key: state.pageKey,
+            child: const RedirectIndicatorPage(),
           );
         },
       ),

--- a/lib/pages/redirect_indicator_page.dart
+++ b/lib/pages/redirect_indicator_page.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:github_browser/features/github_auth/providers/signin_state_provider.dart';
+import 'package:github_browser/l10n/app_localizations.dart';
+
+class RedirectIndicatorPage extends ConsumerStatefulWidget {
+  const RedirectIndicatorPage({super.key});
+
+  @override
+  ConsumerState<RedirectIndicatorPage> createState() => _RedirectIndicatorPageState();
+}
+
+class _RedirectIndicatorPageState extends ConsumerState<RedirectIndicatorPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const SizedBox(height: 200),
+              const CircularProgressIndicator(),
+              const SizedBox(height: 128),
+              ElevatedButton.icon(
+                onPressed: () {
+                  ref.read(signinStateProvider.notifier).signIn();
+                },
+                icon: const Icon(Icons.refresh),
+                label: Text(AppLocalizations.of(context).button_retry),
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                  minimumSize: const Size(200, 0),
+                ),
+              ),
+            ],
+          ),
+        )
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 実施タスク
- [x] リダイレクトが失敗した際にインジケーター以外に、再試行が実施できるようにする

## 実施内容
- RedirectIndicatorPageを作成
- routerにてPageへのルーティングを追加

## 備考
